### PR TITLE
Update 0.5.md

### DIFF
--- a/0.5.md
+++ b/0.5.md
@@ -1,50 +1,5 @@
-### 0.5 go doc和godoc
+### 0.5 godoc
 
- **go doc**
-
-```go doc```命令其实是使用```godoc```命令提取和生成指定代码包的文档的。```go doc```命令做的只是为```godoc```命令检查和设置正确的代码包路径，以及在其上追加几个额外的可用标记。```go doc```命令的可用标记如下表。
-
-_表0-5 ```go doc```命令的标记说明_
-<table class="table table-bordered table-striped table-condensed">
-   <tr>
-    <th width=25%>
-	  标记名称
-	</th>
-    <th>
-	  标记描述
-	</th>
-  </tr>
-  <tr>
-    <td>
-	  -n
-	</td>
-	<td>
-	  打印所用的命令，但是并不真正执行。
-	</td>
-  </tr>
-  <tr>
-    <td>
-	  -x
-	</td>
-	<td>
-	  打印所用的命令。
-	</td>
-  </tr>
-</table>
-
-这两个标记的含义非常简单，而且它们在其它命令中也都是有效的。
-
-```go doc```命令在执行时会首先在检查和设置代码包导入路径。然后将代码包导入路径作为参数传递给```godoc```命令。
-
-    hc@ubt:~/golang/goc2p$ go doc -n  logging 
-    godoc logging
-
-如果我们用本地代码包路径提供代码包位置，那么```go doc```命令会首先把它转换为标准的代码包导入路径，并传递给```godoc```命令。现在我们用代码包的目录相对路径作为命令参数：
-
-	hc@ubt:~/golang/goc2p$ go doc -n  ./src/logging 
-	godoc logging
-	
-我们看到，这里在执行```godoc```命令时同样是以logging作为参数的。
 
 **godoc**
 


### PR DESCRIPTION
Go doc已经被移除出Go的官方工具链了。其实可以考虑是不是把整个godoc section放在别的章节
