### PR TITLE
Fix typo: 'vsc' -> 'vcs'

### DIFF
--- a/0.3.md
+++ b/0.3.md
@@ -101,7 +101,7 @@ hypermind.cn           /talon/analyzer // 导入注释中的导入路径
 <meta name="go-import" content="import-prefix vcs repo-root">
 ```
 
-实际上，`content`属性中的`import-prefix`的位置上应该填入我们自定义的远程代码包导入路径的前缀。这个前缀应该与我们的处理程序关联的那个路径相一致。而`vsc`显然应该代表与版本控制系统有关的标识。还记得表0-2中的主命令列吗？这里的填入内容就应该该列中的某一项。在这里，由于talon项目使用的是Git，所以这里应该填入`git`。至于`repo-root`，它应该是与该处理程序关联的路径对应的Github网站的URL。在这里，这个路径是`hypermind.cn/talon`，那么这个URL就应该是`https://github.com/hyper-carrot/talon`。后者也是talon项目的实际网址。
+实际上，`content`属性中的`import-prefix`的位置上应该填入我们自定义的远程代码包导入路径的前缀。这个前缀应该与我们的处理程序关联的那个路径相一致。而`vcs`显然应该代表与版本控制系统有关的标识。还记得表0-2中的主命令列吗？这里的填入内容就应该该列中的某一项。在这里，由于talon项目使用的是Git，所以这里应该填入`git`。至于`repo-root`，它应该是与该处理程序关联的路径对应的Github网站的URL。在这里，这个路径是`hypermind.cn/talon`，那么这个URL就应该是`https://github.com/hyper-carrot/talon`。后者也是talon项目的实际网址。
 
 好了，在我们做好上述处理程序之后，`go get hypermind.cn/talon/analyzer`命令的执行结果就会是正确的。`analyzer`代码包及其依赖包中的代码会被下载到GOPATH环境变量中的第一个工作区目录的src子目录中，然后被编译并安装。
 


### PR DESCRIPTION
`vsc` -> `vcs`